### PR TITLE
コンパイラに渡されるパスを変更する

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -17,11 +17,11 @@ dependencies {
 }
 
 tasks {
-    create("replaceValuePlaceholder", Copy::class) {
+    create("cloneSource", Copy::class) {
         duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 
-        from(File(buildDir, "tempSrc/main/kotlin/"))
-        into(File(projectDir, "src/main/kotlin/"))
+        from(File(projectDir, "src/main/kotlin/"))
+        into(File(buildDir, "tmpSrc/main/kotlin"))
 
         mapOf(
             "modId" to rootProject.name.toLowerCase(),
@@ -32,8 +32,6 @@ tasks {
 
     compileKotlin {
         destinationDirectory.set(File(buildDir, "classes/java/main"))
-
-        dependsOn("replaceValuePlaceholder")
     }
 
     create("includeResources", Copy::class) {

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -16,12 +16,14 @@ dependencies {
     add("mappings", loom.officialMojangMappings())
 }
 
+val tmpSrcDir = File(buildDir, "tmpSrc/main/kotlin")
+
 tasks {
     create("cloneSource", Copy::class) {
         duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 
         from(File(projectDir, "src/main/kotlin/"))
-        into(File(buildDir, "tmpSrc/main/kotlin"))
+        into(tmpSrcDir)
 
         mapOf(
             "modId" to rootProject.name.toLowerCase(),
@@ -31,7 +33,10 @@ tasks {
     }
 
     compileKotlin {
+        doFirst { source = fileTree(tmpSrcDir) }
         destinationDirectory.set(File(buildDir, "classes/java/main"))
+
+        dependsOn("cloneSource")
     }
 
     create("includeResources", Copy::class) {

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -17,16 +17,6 @@ dependencies {
 }
 
 tasks {
-    create("moveSourceToTemp", Copy::class) {
-        from(File(projectDir, "src/main/kotlin/"))
-        into(File(buildDir, "tempSrc/main/kotlin/"))
-    }
-
-    create("moveSourceFromTemp", Copy::class) {
-        from(File(buildDir, "tempSrc/main/kotlin/"))
-        into(File(projectDir, "src/main/kotlin/"))
-    }
-
     create("replaceValuePlaceholder", Copy::class) {
         duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 
@@ -38,15 +28,12 @@ tasks {
             "modName" to rootProject.name,
             "modVersion" to rootProject.version
         ).let { filter<ReplaceTokens>("tokens" to it) }
-
-        dependsOn(getByName("moveSourceToTemp"))
     }
 
     compileKotlin {
         destinationDirectory.set(File(buildDir, "classes/java/main"))
 
         dependsOn("replaceValuePlaceholder")
-        finalizedBy(getByName("moveSourceFromTemp"))
     }
 
     create("includeResources", Copy::class) {
@@ -62,6 +49,5 @@ tasks {
         dependsOn(getByName("includeResources"))
     }
 
-    getByName("build").dependsOn(getByName("moveSourceFromTemp"))
     getByName("jar").dependsOn(getByName("createLibraryJar"))
 }


### PR DESCRIPTION
Fixes #6
- ソースコードを`src/から`build/tmpSrc/`へ移動、同時にプレースホルダを置換
- Kotlinコンパイラへ渡されるパスを、`src/`から`build/tmpSrc/`へ変更
